### PR TITLE
Add the Reaction–Diffusion interactive explorable

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,6 +49,12 @@ module.exports = function (eleventyConfig) {
 	eleventyConfig.addPassthroughCopy("src/aperture-synthesis");
 	eleventyConfig.ignores.add("src/aperture-synthesis/**");
 
+	// Reaction-diffusion explorable — same deal: a self-contained vanilla-JS sub-app, passed through
+	// verbatim and excluded from 11ty templating. Served at /reaction-diffusion/; source of truth in
+	// ~/Claude/reaction-diffusion.
+	eleventyConfig.addPassthroughCopy("src/reaction-diffusion");
+	eleventyConfig.ignores.add("src/reaction-diffusion/**");
+
 	// A filter to format a date string like "2025-11-14" into "November 14, 2025".
 	// Filters are called in templates with the pipe syntax: {{ image.date | readableDate }}
 	// Implementation lives in lib/filters.js (issue #87).

--- a/src/_data/projects.json
+++ b/src/_data/projects.json
@@ -67,5 +67,16 @@
 		"description": [
 			"A planet-sized array of telescopes can image something as small as a black hole's shadow — this interactive explainer shows how, by letting you play with the machinery. Drag virtual dishes across the ground and watch a sky reconstruct as Earth's rotation fills in the coverage; under the hood it runs the genuine pipeline — sampling the sky's Fourier transform, inverse-transforming the measured visibilities, and deconvolving with CLEAN. The finale loads the actual Event Horizon Telescope M87* visibilities and runs them through the same machine, honestly showing why the famous ring needed more than a naive reconstruction — and why over-deconvolving can invent detail that isn't there. The FFT is hand-rolled and readable, the physics (van Cittert–Zernike) is real, and it runs on real public data. Built as a free exploration alongside Claude Code."
 		]
+	},
+	{
+		"category": "Interactive Explainer",
+		"name": "Reaction–Diffusion",
+		"tech": ["Vanilla JS", "Canvas", "Gray-Scott", "PDE solver"],
+		"links": [
+			{ "label": "Open the explorable", "url": "/reaction-diffusion/" }
+		],
+		"description": [
+			"A leopard's spots, a winding maze, dividing blobs — patterns that look designed, but aren't. This interactive explainer shows how they self-organize from nothing more than two chemicals spreading and reacting on a grid, following Alan Turing's 1952 idea of how an embryo decides where to put its stripes. Paint seeds onto the canvas, then drag a crosshair around the feed/kill phase diagram and watch the pattern morph live — a few thousandths of a change flips spots into stripes into mazes. The Gray-Scott equations are solved by hand in readable vanilla JavaScript at 60fps, no dependencies, no GPU shader; the parameter regimes are the real ones from the literature. Built as a free exploration with Claude Code."
+		]
 	}
 ]

--- a/src/reaction-diffusion/index.html
+++ b/src/reaction-diffusion/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Reaction–Diffusion — patterns from two diffusing chemicals</title>
+	<meta name="description" content="An interactive explainer for reaction-diffusion: two chemicals, two rules, and the patterns — spots, stripes, mazes — that emerge. Play with the feed/kill phase diagram live.">
+	<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+	<header class="intro">
+		<h1>Reaction–Diffusion</h1>
+		<p class="tagline">Two chemicals, two simple rules, no blueprint — and patterns appear.</p>
+		<p class="lede">A leopard's spots, a winding maze, the spiral waves of a chemical clock — all of them
+			can emerge from nothing more than two substances spreading and reacting across a surface. Nobody
+			draws the pattern; it organizes itself. Play with the machine below, then read how just two
+			numbers — how fast you <i>feed</i> and how fast you <i>kill</i> — decide what you get.</p>
+	</header>
+
+	<main class="app">
+		<section class="stage">
+			<canvas id="cv" width="256" height="256" aria-label="Reaction-diffusion pattern"></canvas>
+			<p class="hint">Drag on the canvas to paint new seeds. Pick a regime, drag the phase map, or move the sliders.</p>
+		</section>
+
+		<aside class="panel">
+			<div class="regime" id="regime">Mitosis</div>
+			<div class="fk" id="fk-readout">feed 0.0367 · kill 0.0649</div>
+
+			<div class="group">
+				<span class="label">Phase map — drag to explore</span>
+				<canvas id="phasemap" width="272" height="168" class="phasemap" aria-label="Feed–kill phase diagram; drag to set parameters"></canvas>
+			</div>
+
+			<div class="group">
+				<span class="label">Regime</span>
+				<div class="presets">
+					<button data-preset="mitosis" aria-pressed="true">Mitosis</button>
+					<button data-preset="coral" aria-pressed="false">Coral</button>
+					<button data-preset="maze" aria-pressed="false">Maze</button>
+					<button data-preset="solitons" aria-pressed="false">Solitons</button>
+					<button data-preset="worms" aria-pressed="false">Worms</button>
+					<button data-preset="waves" aria-pressed="false">Waves</button>
+				</div>
+			</div>
+
+			<div class="group">
+				<label class="slider"><span class="label">Feed <i>f</i></span>
+					<input id="f-slider" type="range" min="0.010" max="0.080" step="0.0001" value="0.0367"></label>
+				<label class="slider"><span class="label">Kill <i>k</i></span>
+					<input id="k-slider" type="range" min="0.040" max="0.070" step="0.0001" value="0.0649"></label>
+			</div>
+
+			<div class="group buttons">
+				<button id="play">⏸ Pause</button>
+				<button id="reset">↺ Reset</button>
+				<button id="clear">▢ Clear</button>
+			</div>
+
+			<div class="group">
+				<span class="label">Palette</span>
+				<div class="presets">
+					<button data-palette="teal" aria-pressed="true">Teal</button>
+					<button data-palette="ember" aria-pressed="false">Ember</button>
+					<button data-palette="mono" aria-pressed="false">Mono</button>
+				</div>
+			</div>
+		</aside>
+	</main>
+
+	<article class="explainer">
+		<section>
+			<h2>The two rules</h2>
+			<p>Imagine two chemicals, <b>A</b> and <b>B</b>, on a grid. Both <b>diffuse</b> — they spread into
+				neighbouring cells, blurring out. And where they meet they <b>react</b>: one molecule of A plus two
+				of B becomes three of B. B eats A and makes more of itself — autocatalysis. Two more knobs finish the
+				world: a <b>feed</b> rate <i>f</i> tops A back up everywhere, and a <b>kill</b> rate <i>k</i> removes B.
+				That's all there is. No rule says "make a spot." The spots are a <i>consequence</i>.</p>
+			<p class="eq">∂A/∂t = D<sub>A</sub>∇²A − AB² + f(1−A)　　∂B/∂t = D<sub>B</sub>∇²B + AB² − (k+f)B</p>
+			<p>The reaction wants to make blobs of B; diffusion wants to smear them out; the feed and kill set the
+				balance. Where those forces settle is the pattern.</p>
+		</section>
+
+		<section>
+			<h2>Why feed and kill change everything</h2>
+			<p>The little map in the controls is the <b>phase diagram</b>: every point is a pair of feed/kill values,
+				and which point you're standing on decides whether you get spots, stripes, a maze, or dividing blobs.
+				The boundaries between regimes are sharp — nudge <i>f</i> by a few thousandths and the whole character
+				flips. That's the surprise reaction-diffusion keeps teaching: the same machine, a hair's-breadth apart in
+				parameter space, produces wildly different worlds. Drag the crosshair around and watch it happen.</p>
+		</section>
+
+		<section>
+			<h2>From a leopard's coat to a chemical clock</h2>
+			<p>This isn't just pretty math. In 1952 Alan Turing proposed — in his last paper — that exactly this kind of
+				two-chemical system is how a featureless embryo decides where to put stripes and spots. The same
+				equations predict animal coats, seashell markings, the spacing of hair follicles. The pattern isn't
+				stored anywhere; it falls out of the chemistry.</p>
+			<p>And it has a second face. Tune the same engine into an <b>excitable</b> regime and the patterns stop sitting
+				still and start to <i>travel</i> — rotating spirals and expanding target rings. That's the
+				<a href="https://en.wikipedia.org/wiki/Belousov%E2%80%93Zhabotinsky_reaction">Belousov–Zhabotinsky
+				reaction</a>, the mesmerizing chemical clock you may have seen spiralling across a petri dish. Spots and
+				spirals look like different phenomena; they're the same two-chemicals-diffusing idea in different
+				neighbourhoods of its own phase diagram. (This tool explores the stationary-pattern side; the travelling-wave
+				side is a natural next addition.)</p>
+		</section>
+
+		<footer class="colophon">
+			Built as a free exploration with Claude Code. Vanilla JavaScript, a hand-written Gray-Scott solver, no
+			dependencies. The physics is real; the parameter regimes are the well-known ones from the literature.
+		</footer>
+	</article>
+
+	<script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/reaction-diffusion/src/main.js
+++ b/src/reaction-diffusion/src/main.js
@@ -1,0 +1,94 @@
+// main.js — the interactive reaction-diffusion explorable. Steps the Gray-Scott sim every frame,
+// renders B through a palette, and wires the controls: named-regime presets, live feed/kill sliders,
+// paint-to-seed, play/pause, reset, clear, palette. (Teaching copy + the BZ wave mode come later.)
+import { makeFields, seedSquare, step, swap, stamp, clear } from './sim.js';
+import { renderField, PALETTES } from './render.js';
+import { makePhaseMap } from './phasemap.js';
+
+const W = 256, H = 256;
+const $ = (id) => document.getElementById(id);
+
+// Named Gray-Scott regimes (feed f, kill k). Each lands in a different region of the phase diagram
+// and produces a distinct pattern — the values are the well-known ones from the Gray-Scott literature.
+const PRESETS = [
+	{ id: 'mitosis', f: 0.0367, k: 0.0649, name: 'Mitosis', blurb: 'blobs that split and replicate like dividing cells' },
+	{ id: 'coral', f: 0.0545, k: 0.0620, name: 'Coral', blurb: 'branching, growing coral fronts' },
+	{ id: 'maze', f: 0.0290, k: 0.0570, name: 'Maze', blurb: 'winding labyrinth corridors' },
+	{ id: 'solitons', f: 0.0300, k: 0.0620, name: 'Solitons', blurb: 'stable persistent dots that bounce, never merging' },
+	{ id: 'worms', f: 0.0540, k: 0.0630, name: 'Worms', blurb: 'wriggling worm-like stripes' },
+	{ id: 'waves', f: 0.0140, k: 0.0540, name: 'Waves', blurb: 'expanding wavefronts — a glimpse of the BZ regime' },
+];
+
+const state = { f: PRESETS[0].f, k: PRESETS[0].k, running: true, steps: 8, palette: PALETTES.teal };
+let phasemap = null;   // assigned after the controls are wired (see below); guarded with ?.
+const fields = makeFields(W, H);
+seedSquare(fields, 24);
+
+const cv = $('cv'), ctx = cv.getContext('2d', { alpha: false });
+const img = ctx.createImageData(W, H);
+
+// setFK — set feed/kill, sync the sliders + numeric readout. `label` describes the regime.
+function setFK(f, k, label) {
+	state.f = f; state.k = k;
+	$('f-slider').value = String(f); $('k-slider').value = String(k);
+	$('fk-readout').textContent = `feed ${f.toFixed(4)} · kill ${k.toFixed(4)}`;
+	if (label) $('regime').textContent = label;
+}
+
+// applyPreset — jump to a regime: set f/k, wipe the dish, drop a fresh seed so the pattern grows
+// from scratch, and mark the active button.
+function applyPreset(p) {
+	setFK(p.f, p.k, `${p.name} — ${p.blurb}`);
+	clear(fields); seedSquare(fields, 24);
+	phasemap?.setCur(p.f, p.k);
+	document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', String(b.dataset.preset === p.id)));
+}
+
+// paint-to-seed — stamp B under the pointer; map canvas client coords → grid cells (the canvas is
+// displayed larger than its 256² backing store, so scale by the rendered size).
+let painting = false;
+function paintAt(ev) {
+	const r = cv.getBoundingClientRect();
+	const gx = Math.floor((ev.clientX - r.left) / r.width * W);
+	const gy = Math.floor((ev.clientY - r.top) / r.height * H);
+	stamp(fields, gx, gy, 6);
+}
+cv.addEventListener('pointerdown', (e) => { painting = true; cv.setPointerCapture(e.pointerId); paintAt(e); });
+cv.addEventListener('pointermove', (e) => { if (painting) paintAt(e); });
+cv.addEventListener('pointerup', () => { painting = false; });
+cv.addEventListener('pointercancel', () => { painting = false; });
+
+// --- wire controls ---
+document.querySelectorAll('[data-preset]').forEach((b) =>
+	b.addEventListener('click', () => applyPreset(PRESETS.find((p) => p.id === b.dataset.preset))));
+
+const onSlider = () => { setFK(+$('f-slider').value, +$('k-slider').value); phasemap?.setCur(state.f, state.k); $('regime').textContent = 'custom — explore the phase diagram'; document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', 'false')); };
+$('f-slider').addEventListener('input', onSlider);
+$('k-slider').addEventListener('input', onSlider);
+
+$('play').addEventListener('click', () => { state.running = !state.running; $('play').textContent = state.running ? '⏸ Pause' : '▶ Play'; });
+$('reset').addEventListener('click', () => { clear(fields); seedSquare(fields, 24); });
+$('clear').addEventListener('click', () => clear(fields));
+document.querySelectorAll('[data-palette]').forEach((b) =>
+	b.addEventListener('click', () => {
+		state.palette = PALETTES[b.dataset.palette];
+		document.querySelectorAll('[data-palette]').forEach((x) => x.setAttribute('aria-pressed', String(x === b)));
+	}));
+
+// Phase map: dragging it sets f/k LIVE without reseeding, so the current pattern morphs through
+// phase space (the most illuminating way to feel how f/k shape the result).
+phasemap = makePhaseMap($('phasemap'), PRESETS, (f, k, fresh) => {
+	setFK(f, k);
+	if (fresh) { clear(fields); seedSquare(fields, 24); }   // tap = fresh start; drag = morph live
+	$('regime').textContent = 'custom — drag through phase space';
+	document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', 'false'));
+});
+
+// --- the loop: advance several steps per frame (RD evolves slowly), then paint the field ---
+function loop() {
+	if (state.running) for (let s = 0; s < state.steps; s++) { step(fields, state.f, state.k); swap(fields); }
+	renderField(ctx, img, fields.b, state.palette);
+	requestAnimationFrame(loop);
+}
+applyPreset(PRESETS[0]);
+requestAnimationFrame(loop);

--- a/src/reaction-diffusion/src/phasemap.js
+++ b/src/reaction-diffusion/src/phasemap.js
@@ -1,0 +1,54 @@
+// phasemap.js — a little interactive map of the Gray-Scott (feed f, kill k) plane. It plots the
+// named regimes as labelled points and a live crosshair at the current (f,k); click or drag inside
+// it to set f/k and watch the live pattern morph through phase space. Deliberately NOT a pre-painted
+// region map — that would fake precise boundaries; the running simulation is the honest ground truth,
+// and this is just orientation ("where am I relative to the named regimes").
+const F_MIN = 0.010, F_MAX = 0.080, K_MIN = 0.040, K_MAX = 0.070, PAD = 20;
+
+// makePhaseMap — draw into `canvas`, plotting `presets` (each {f,k,name}); call `onPick(f,k)` while
+// the user drags. Returns { setCur } so the host can move the crosshair when sliders/presets change.
+export function makePhaseMap(canvas, presets, onPick) {
+	const ctx = canvas.getContext('2d');
+	const W = canvas.width, H = canvas.height;
+	const fx = (f) => PAD + (f - F_MIN) / (F_MAX - F_MIN) * (W - 2 * PAD);
+	const ky = (k) => PAD + (k - K_MIN) / (K_MAX - K_MIN) * (H - 2 * PAD);
+	const xToF = (x) => F_MIN + (x - PAD) / (W - 2 * PAD) * (F_MAX - F_MIN);
+	const yToK = (y) => K_MIN + (y - PAD) / (H - 2 * PAD) * (K_MAX - K_MIN);
+	const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+	let cur = { f: presets[0].f, k: presets[0].k };
+
+	function draw() {
+		ctx.clearRect(0, 0, W, H);
+		ctx.strokeStyle = '#1c2433'; ctx.lineWidth = 1; ctx.strokeRect(PAD, PAD, W - 2 * PAD, H - 2 * PAD);
+		ctx.fillStyle = '#5a6678'; ctx.font = '9px ui-monospace';
+		ctx.fillText('feed →', W - PAD - 38, H - 6);
+		ctx.save(); ctx.translate(11, PAD + 40); ctx.rotate(-Math.PI / 2); ctx.fillText('kill →', 0, 0); ctx.restore();
+		for (const p of presets) {                       // named-regime points
+			const x = fx(p.f), y = ky(p.k);
+			ctx.fillStyle = 'rgba(95,208,200,0.45)'; ctx.beginPath(); ctx.arc(x, y, 3, 0, 7); ctx.fill();
+			ctx.fillStyle = '#7c8aa0'; ctx.font = '8px ui-monospace'; ctx.fillText(p.name, x + 5, y + 3);
+		}
+		const cx = fx(cur.f), cy = ky(cur.k);            // live crosshair
+		ctx.strokeStyle = '#5fd0c8'; ctx.lineWidth = 2;
+		ctx.beginPath(); ctx.arc(cx, cy, 5, 0, 7); ctx.stroke();
+		ctx.beginPath(); ctx.moveTo(cx - 9, cy); ctx.lineTo(cx + 9, cy); ctx.moveTo(cx, cy - 9); ctx.lineTo(cx, cy + 9); ctx.stroke();
+	}
+
+	// onPick(f, k, fresh): `fresh` is true on a fresh tap (pointerdown), false while dragging — so the
+	// host can RESEED on a tap (always show what a region makes from a clean start) but MORPH on drag
+	// (a smooth glide through phase space). Reseeding mid-drag would just restart every frame.
+	let dragging = false;
+	const pick = (ev, fresh) => {
+		const r = canvas.getBoundingClientRect();
+		const f = clamp(xToF((ev.clientX - r.left) / r.width * W), F_MIN, F_MAX);
+		const k = clamp(yToK((ev.clientY - r.top) / r.height * H), K_MIN, K_MAX);
+		cur = { f, k }; draw(); onPick(f, k, fresh);
+	};
+	canvas.addEventListener('pointerdown', (e) => { dragging = true; canvas.setPointerCapture(e.pointerId); pick(e, true); });
+	canvas.addEventListener('pointermove', (e) => { if (dragging) pick(e, false); });
+	canvas.addEventListener('pointerup', () => { dragging = false; });
+	canvas.addEventListener('pointercancel', () => { dragging = false; });
+
+	draw();
+	return { setCur(f, k) { cur = { f, k }; draw(); } };
+}

--- a/src/reaction-diffusion/src/render.js
+++ b/src/reaction-diffusion/src/render.js
@@ -1,0 +1,39 @@
+// render.js — map the B field to pixels through a colour lookup table. Kept separate from the sim
+// so colour is a pure presentation concern (and so palettes are easy to add later).
+
+// makeLUT — build a 256-entry RGB lookup table from a list of [stop, r,g,b] colour stops (stop in
+// 0..1), linearly interpolated. Precomputing means the per-pixel render is a single table lookup.
+export function makeLUT(stops) {
+	const lut = new Uint8Array(256 * 3);
+	for (let i = 0; i < 256; i++) {
+		const t = i / 255;
+		let s = 0;
+		while (s < stops.length - 2 && stops[s + 1][0] < t) s++;
+		const [t0, r0, g0, b0] = stops[s], [t1, r1, g1, b1] = stops[Math.min(s + 1, stops.length - 1)];
+		const u = t1 > t0 ? (t - t0) / (t1 - t0) : 0;
+		lut[i * 3] = r0 + (r1 - r0) * u;
+		lut[i * 3 + 1] = g0 + (g1 - g0) * u;
+		lut[i * 3 + 2] = b0 + (b1 - b0) * u;
+	}
+	return lut;
+}
+
+// A couple of palettes (each a stop list). "teal" reads like the BZ dish; "ember" is warm.
+export const PALETTES = {
+	teal: makeLUT([[0, 8, 12, 22], [0.4, 18, 90, 96], [0.7, 90, 210, 200], [1, 240, 255, 250]]),
+	ember: makeLUT([[0, 10, 6, 14], [0.45, 120, 24, 40], [0.75, 240, 120, 30], [1, 255, 240, 180]]),
+	mono: makeLUT([[0, 6, 8, 13], [1, 235, 240, 250]]),
+};
+
+// renderField — write B (scaled by `hi`, the expected max ≈ 0.4) through `lut` into the ImageData,
+// then blit to the canvas context. ctx/img are reused across frames by the caller.
+export function renderField(ctx, img, b, lut, hi = 0.4) {
+	const data = img.data, n = b.length, scale = 255 / hi;
+	for (let i = 0; i < n; i++) {
+		let c = (b[i] * scale) | 0;
+		if (c < 0) c = 0; else if (c > 255) c = 255;
+		const o = i * 4, l = c * 3;
+		data[o] = lut[l]; data[o + 1] = lut[l + 1]; data[o + 2] = lut[l + 2]; data[o + 3] = 255;
+	}
+	ctx.putImageData(img, 0, 0);
+}

--- a/src/reaction-diffusion/src/sim.js
+++ b/src/reaction-diffusion/src/sim.js
@@ -1,0 +1,83 @@
+// sim.js — the Gray-Scott reaction-diffusion core.
+//
+// Two fields live on a W×H toroidal (wrap-around) grid: A (the substrate) and B (the
+// autocatalyst). Every step, each cell follows two local rules — that's the whole engine:
+//   A' = A + (Da·∇²A − A·B² + f·(1−A)) · dt     (A diffuses, is eaten by the reaction, is fed back)
+//   B' = B + (Db·∇²B + A·B² − (k+f)·B) · dt     (B diffuses, is made by the reaction, decays)
+// The A·B² term is the reaction: one A meets two B and becomes a third B (autocatalysis). With dt=1
+// folded in (the standard discrete form), `f` (feed) and `k` (kill) are the two knobs that move the
+// system across the whole zoo of patterns — spots, stripes, mazes, waves.
+//
+// ∇² is a 9-point Laplacian (orthogonal neighbours weighted 0.2, diagonals 0.05, centre −1). The
+// weights sum to zero (a Laplacian must) and the diagonal terms make it more ISOTROPIC than a
+// 5-point stencil, so patterns don't lock to the grid axes. Da=1.0, Db=0.5 are the canonical rates.
+
+export const Da = 1.0, Db = 0.5;
+
+// makeFields — allocate the A/B fields plus their double-buffers. A starts at 1 (full substrate),
+// B at 0 (no autocatalyst). Returns the four flat Float32Arrays the stepper ping-pongs between.
+export function makeFields(w, h) {
+	const n = w * h;
+	const a = new Float32Array(n).fill(1), b = new Float32Array(n);
+	const a2 = new Float32Array(n), b2 = new Float32Array(n);
+	return { a, b, a2, b2, w, h };
+}
+
+// seedSquare — drop a square of B (and half-strength A) at the centre, plus a little noise, to break
+// symmetry so a pattern can nucleate. rand is an injectable RNG (default Math.random) for testability.
+export function seedSquare(fields, side = 20, rand = Math.random) {
+	const { a, b, w, h } = fields;
+	const x0 = (w - side) >> 1, y0 = (h - side) >> 1;
+	for (let y = y0; y < y0 + side; y++)
+		for (let x = x0; x < x0 + side; x++) {
+			const i = y * w + x;
+			a[i] = 0.5 + (rand() - 0.5) * 0.02;
+			b[i] = 0.25 + (rand() - 0.5) * 0.02;
+		}
+}
+
+// step — advance the simulation by ONE Euler step (the hot loop). Reads a/b, writes a2/b2; the
+// caller swaps the buffers. Wrap indices are precomputed per row/column so the inner loop has no
+// modulo or branches. `f` = feed rate, `k` = kill rate.
+export function step(fields, f, k) {
+	const { a, b, a2, b2, w, h } = fields;
+	for (let y = 0; y < h; y++) {
+		const yc = y * w;
+		const ym = (y === 0 ? h - 1 : y - 1) * w;
+		const yp = (y === h - 1 ? 0 : y + 1) * w;
+		for (let x = 0; x < w; x++) {
+			const xm = x === 0 ? w - 1 : x + (-1);
+			const xp = x === w - 1 ? 0 : x + 1;
+			const i = yc + x;
+			const av = a[i], bv = b[i];
+			const lapA = (a[yc + xm] + a[yc + xp] + a[ym + x] + a[yp + x]) * 0.2
+				+ (a[ym + xm] + a[ym + xp] + a[yp + xm] + a[yp + xp]) * 0.05 - av;
+			const lapB = (b[yc + xm] + b[yc + xp] + b[ym + x] + b[yp + x]) * 0.2
+				+ (b[ym + xm] + b[ym + xp] + b[yp + xm] + b[yp + xp]) * 0.05 - bv;
+			const abb = av * bv * bv;                       // the autocatalytic reaction term
+			a2[i] = av + (Da * lapA - abb + f * (1 - av));
+			b2[i] = bv + (Db * lapB + abb - (k + f) * bv);
+		}
+	}
+}
+
+// swap — ping-pong the buffers after a step (a2/b2 become the current a/b). Returns fields for chaining.
+export function swap(fields) {
+	[fields.a, fields.a2] = [fields.a2, fields.a];
+	[fields.b, fields.b2] = [fields.b2, fields.b];
+	return fields;
+}
+
+// stamp — paint a filled disk of autocatalyst B (and depleted A) into the field, e.g. under the
+// user's brush, so they can seed new pattern wherever they drag. cx/cy in grid cells; wraps toroidally.
+export function stamp(fields, cx, cy, r) {
+	const { a, b, w, h } = fields;
+	for (let dy = -r; dy <= r; dy++) for (let dx = -r; dx <= r; dx++) {
+		if (dx * dx + dy * dy > r * r) continue;
+		const x = ((cx + dx) % w + w) % w, y = ((cy + dy) % h + h) % h, i = y * w + x;
+		b[i] = 0.9; a[i] = 0.1;
+	}
+}
+
+// clear — reset to the homogeneous rest state (A=1 everywhere, B=0): a blank dish.
+export function clear(fields) { fields.a.fill(1); fields.b.fill(0); }

--- a/src/reaction-diffusion/styles.css
+++ b/src/reaction-diffusion/styles.css
@@ -1,0 +1,71 @@
+:root {
+	--bg: #06080d; --panel: #0c1018; --line: #1c2433; --ink: #cdd6e4; --ink-dim: #7c8aa0;
+	--accent: #5fd0c8; --accent-dim: rgba(95, 208, 200, 0.14);
+	--mono: ui-monospace, "SF Mono", "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body {
+	margin: 0; background: radial-gradient(120% 80% at 50% 0%, #0a0e16 0%, #06080d 55%);
+	color: var(--ink); font-family: var(--mono); line-height: 1.4; min-height: 100vh;
+	display: flex; flex-direction: column; align-items: center; gap: 2.6rem; padding: 3rem 1.5rem 5rem;
+}
+.app { display: flex; gap: 2rem; align-items: flex-start; flex-wrap: wrap; justify-content: center; }
+
+.intro { max-width: 640px; text-align: center; display: flex; flex-direction: column; gap: 0.8rem; }
+.intro h1 { font-size: 2rem; margin: 0; letter-spacing: 0.01em; }
+.tagline { color: var(--accent); font-size: 1rem; margin: 0; }
+.lede { color: var(--ink-dim); font-size: 0.86rem; line-height: 1.65; margin: 0; }
+.intro i { color: var(--accent); font-style: italic; }
+
+.explainer { max-width: 660px; display: flex; flex-direction: column; gap: 1.8rem; width: 100%; }
+.explainer h2 { font-size: 1.05rem; color: var(--accent); margin: 0 0 0.5rem; }
+.explainer p { color: var(--ink-dim); font-size: 0.84rem; line-height: 1.7; margin: 0 0 0.7rem; }
+.explainer b { color: var(--ink); font-weight: 600; }
+.explainer i { color: var(--accent); font-style: italic; }
+.explainer a { color: var(--accent); text-underline-offset: 2px; }
+.eq {
+	color: var(--ink) !important; background: var(--panel); border: 1px solid var(--line);
+	border-radius: 8px; padding: 0.85rem 1rem; text-align: center; font-size: 0.8rem; overflow-x: auto;
+}
+.colophon { color: var(--ink-dim); font-size: 0.72rem; line-height: 1.6; border-top: 1px solid var(--line); padding-top: 1.2rem; }
+
+.stage { display: flex; flex-direction: column; gap: 0.6rem; align-items: center; }
+#cv {
+	width: 512px; height: 512px; max-width: 80vw; max-height: 80vw;
+	image-rendering: pixelated; border: 1px solid var(--line); border-radius: 6px;
+	cursor: crosshair; touch-action: none; background: #000;
+}
+.hint { color: var(--ink-dim); font-size: 0.74rem; margin: 0; max-width: 512px; text-align: center; }
+
+.panel {
+	width: 320px; background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+	padding: 1.4rem; display: flex; flex-direction: column; gap: 1rem;
+}
+.panel h1 { font-size: 1.1rem; margin: 0; letter-spacing: 0.01em; }
+.sub { color: var(--ink-dim); font-size: 0.76rem; line-height: 1.5; margin: 0; }
+
+.regime { font-size: 0.92rem; color: var(--accent); }
+.fk { font-size: 0.72rem; color: var(--ink-dim); margin-top: -0.6rem; }
+
+.group { display: flex; flex-direction: column; gap: 0.5rem; }
+.label { font-size: 0.6rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-dim); }
+.label i { color: var(--accent); font-style: italic; }
+
+.presets { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.presets button, .buttons button {
+	flex: 1 1 4.5rem; min-height: 40px;
+	font-family: var(--mono); font-size: 0.74rem; color: var(--accent);
+	background: var(--accent-dim); border: 1px solid rgba(95, 208, 200, 0.35); border-radius: 8px;
+	padding: 0.4rem 0.5rem; cursor: pointer; transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.presets button:hover, .buttons button:hover { background: rgba(95, 208, 200, 0.22); border-color: var(--accent); }
+.presets button[aria-pressed="true"] { background: var(--accent); color: var(--bg); border-color: var(--accent); font-weight: 600; }
+.presets button:focus-visible, .buttons button:focus-visible, input:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.phasemap {
+	width: 100%; height: auto; aspect-ratio: 272 / 168; display: block;
+	background: #080b12; border: 1px solid var(--line); border-radius: 8px; cursor: crosshair; touch-action: none;
+}
+.slider { display: flex; flex-direction: column; gap: 0.35rem; }
+input[type="range"] { width: 100%; accent-color: var(--accent); }
+.buttons { flex-direction: row; }


### PR DESCRIPTION
## What
Adds a **Reaction–Diffusion** explorable at `/reaction-diffusion/`, linked from the projects page — a second free-exploration explainer alongside Aperture Synthesis. Two chemicals diffusing on a grid (Gray-Scott) self-organize into spots, stripes, mazes, dividing blobs — Turing's 1952 morphogenesis idea, made playable.

## What's in it
- A live 256² Gray-Scott simulation, hand-written PDE solver — **60 fps, zero dependencies, no GPU shader** (the perf spike showed vanilla JS had ~12× headroom, so it stays readable).
- **6 named regimes** (mitosis, coral, maze, solitons, worms, waves) + live feed/kill sliders.
- An interactive **phase-diagram map** — drag a crosshair around the feed/kill plane and watch the pattern morph through phase space; tap a region to see it from a fresh seed.
- Paint-to-seed, play/pause/reset/clear, three palettes, and a written **explainer** (the two rules + equations, the phase diagram, the Turing-morphogenesis and BZ connections).

## How it's wired
- `.eleventy.js` passthrough-copies `src/reaction-diffusion/` verbatim (+ ignore), same pattern as Aperture Synthesis.
- One `src/_data/projects.json` entry.
- System monospace fonts — **no CDN font**, so no CSP/GDPR concern (lesson applied).

## Honest note
The **Belousov–Zhabotinsky spiral-wave mode** (the rotating spirals from that NileRed reaction) is **deferred**. I built the excitable-medium core and made ~7 genuine attempts, but clean spirals sit in a narrow regime that needs careful numerics rather than parameter-guessing — so I stopped rather than rabbit-hole. The WIP (`barkley.js`) is **excluded** from this deploy; the explainer flags the BZ side as a natural next addition, and the "Waves" Gray-Scott preset gestures at traveling waves. Doing the spiral mode *right* is a focused follow-up.

## Verification
- 60 fps at 256²; all regimes render; phase-map tap/drag works; built `_site/` serves it at `/reaction-diffusion/` with **zero console errors**.

Projects-page description voice is yours to adjust (same as last time). Merge → live on dustin.space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)