### PR TITLE
Add a "Claude's Corner" section to the projects page

### DIFF
--- a/src/_data/projects.json
+++ b/src/_data/projects.json
@@ -59,6 +59,7 @@
 	},
 	{
 		"category": "Interactive Explainer",
+		"claudeDriven": true,
 		"name": "Aperture Synthesis",
 		"tech": ["Vanilla JS", "Canvas", "Hand-rolled FFT", "CLEAN", "Real EHT data"],
 		"links": [
@@ -70,6 +71,7 @@
 	},
 	{
 		"category": "Interactive Explainer",
+		"claudeDriven": true,
 		"name": "Reaction–Diffusion",
 		"tech": ["Vanilla JS", "Canvas", "Gray-Scott", "PDE solver"],
 		"links": [

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2345,6 +2345,35 @@ p + p {
 	margin-top: var(--space-12);
 }
 
+/* CLAUDE'S CORNER — a section set apart for the explorables Claude conceived and built on its
+   own. A heavier accent divider + a marked heading distinguish it from my own projects above
+   without breaking the page's cohesion (it reuses .projects-list / .project-row underneath). */
+.claude-corner {
+	margin-top: var(--space-20);
+	padding-top: var(--space-12);
+	border-top: 1px solid var(--accent);
+}
+.claude-corner-head { max-width: 62ch; }
+.claude-corner h2 {
+	font-family: var(--font-heading);
+	font-size: 1.75rem;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin: 0;
+}
+.claude-corner h2::before {
+	content: "\2726";   /* ✦ — a small star mark, nodding to the site's astro theme */
+	color: var(--accent);
+	margin-right: var(--space-3);
+	font-size: 0.85em;
+}
+.claude-corner-intro {
+	color: var(--text-secondary);
+	margin-top: var(--space-3);
+	max-width: 62ch;
+}
+.claude-corner .projects-list { margin-top: var(--space-8); }
+
 /*
  * Each row fades up on page load, reusing the gallery's card-enter
  * keyframes (defined in the GALLERY section — @keyframes are global).

--- a/src/projects/index.njk
+++ b/src/projects/index.njk
@@ -1,25 +1,50 @@
 ---
 layout: layouts/base.njk
 title: Projects
-description: "Software projects and upstream contributions — KDE widgets, GPU acceleration for astrophotography processing, an SDDM race fix, and Claude Code tooling."
+description: "Software projects and upstream contributions — KDE widgets, GPU acceleration for astrophotography processing, an SDDM race fix, Claude Code tooling, and a corner of explorables built autonomously by Claude."
 permalink: /projects/
 ---
 
-<!--
-	PROJECTS PAGE
-	All content is driven from src/_data/projects.json — same pattern as the
-	Setup page (gear.json). Adding a sixth project later means adding one JSON
-	entry; this template never changes.
+{#
+	PROJECTS PAGE — driven from src/_data/projects.json.
 
-	`projects` is the array from projects.json, automatically exposed by 11ty
-	as a global named after the file. Page order = array order.
+	Projects split into two sections: the ones I drive, and "Claude's Corner" — the
+	entries flagged "claudeDriven": true in the JSON, free-exploration explorables Claude
+	picked and built on its own. The row markup lives in the projectRow macro so it isn't
+	duplicated across the two sections; adding a project is still one JSON entry (set
+	claudeDriven to route it into the corner). The filtering uses a simple `if` on each
+	pass rather than selectattr — no dependency on a Jinja-only filter.
 
-	Layout: each project is a full-width row — metadata column on the left
-	(category, name, tech list, links), narrative description on the right.
-	Chosen over a card grid because the descriptions are the point of this
-	page; rows give each project's story room to breathe. Rows stack on
-	mobile (see PROJECTS PAGE section in main.css).
--->
+	Layout: each project is a full-width row — metadata column on the left, narrative
+	description on the right. Rows over cards because the descriptions are the point.
+#}
+
+{% macro projectRow(project) %}
+<article class="project-row">
+	<div class="project-meta">
+		<p class="project-category">
+			{{ project.category }}
+			{% if project.status %}<span class="project-status">{{ project.status }}</span>{% endif %}
+		</p>
+		<h2 class="project-name">{{ project.name }}</h2>
+		<p class="project-tech">{{ project.tech | join(" · ") }}</p>
+		<ul class="project-links">
+			{% for link in project.links %}
+			<li>
+				<a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ project.name }} — {{ link.label }}">
+					{{ link.label }}&nbsp;<span class="link-arrow" aria-hidden="true">&rarr;</span>
+				</a>
+			</li>
+			{% endfor %}
+		</ul>
+	</div>
+	<div class="project-description">
+		{% for para in project.description %}
+		<p>{{ para }}</p>
+		{% endfor %}
+	</div>
+</article>
+{% endmacro %}
 
 <div class="projects-page">
 	<div class="container">
@@ -34,62 +59,26 @@ permalink: /projects/
 			</p>
 		</div>
 
+		<!-- My projects -->
 		<div class="projects-list">
-			<!--
-				One <article> per project. article (not div) because each row is
-				self-contained, independently understandable content — the element
-				screen readers and feed scrapers treat as a standalone unit.
-			-->
-			{% for project in projects %}
-			<article class="project-row">
-
-				<div class="project-meta">
-					<p class="project-category">
-						{{ project.category }}
-						{# Status badge renders only when the JSON entry has a
-						   "status" field — currently just the SDDM open PR. #}
-						{% if project.status %}<span class="project-status">{{ project.status }}</span>{% endif %}
-					</p>
-
-					<h2 class="project-name">{{ project.name }}</h2>
-
-					<!--
-						`join` is a Nunjucks filter: takes the tech array from JSON
-						and produces one string with " · " between items — so the
-						separator lives here, not in the data.
-					-->
-					<p class="project-tech">{{ project.tech | join(" · ") }}</p>
-
-					<!--
-						Links wrapped in a list (footer-nav convention) so screen
-						readers announce "list, N items". aria-label disambiguates
-						repeated link text — three projects all have a "GitHub"
-						link; out of context they'd be indistinguishable without it.
-						The arrow is decorative (aria-hidden) and animated on hover
-						via CSS.
-					-->
-					<ul class="project-links">
-						{% for link in project.links %}
-						<li>
-							<a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ project.name }} — {{ link.label }}">
-								{{ link.label }}&nbsp;<span class="link-arrow" aria-hidden="true">&rarr;</span>
-							</a>
-						</li>
-						{% endfor %}
-					</ul>
-				</div>
-
-				<div class="project-description">
-					{# description is an array of paragraphs (usually one) so a
-					   project's story can grow without a schema change. #}
-					{% for para in project.description %}
-					<p>{{ para }}</p>
-					{% endfor %}
-				</div>
-
-			</article>
-			{% endfor %}
+			{% for project in projects %}{% if not project.claudeDriven %}{{ projectRow(project) }}{% endif %}{% endfor %}
 		</div>
+
+		<!-- Claude's Corner — the autonomous, Claude-driven explorables, set apart -->
+		<section class="claude-corner" aria-labelledby="claude-corner-heading">
+			<div class="claude-corner-head">
+				<h2 id="claude-corner-heading">Claude's Corner</h2>
+				<p class="claude-corner-intro">
+					Projects I handed to Claude with no brief beyond "pick something you'd
+					find interesting and build it." It chose the topic, designed it, and wrote
+					every line; I weighed in on direction and called when to ship. A look at
+					what an AI makes when it's the one driving.
+				</p>
+			</div>
+			<div class="projects-list">
+				{% for project in projects %}{% if project.claudeDriven %}{{ projectRow(project) }}{% endif %}{% endfor %}
+			</div>
+		</section>
 
 	</div>
 </div>


### PR DESCRIPTION
## What
Adds a **"Claude's Corner"** section to the projects page, grouping the two explorables Claude built autonomously (Aperture Synthesis, Reaction–Diffusion) apart from your own projects.

## How
- Tagged the two explorables with `"claudeDriven": true` in `projects.json`.
- Rewrote `src/projects/index.njk`: the row markup is now a Nunjucks **macro**, rendered in two filtered passes — your projects first, then the Claude's Corner section. (Plain `if` filter, no Jinja-only `selectattr` dependency.)
- Styled it in `main.css`: an accent divider + a ✦-marked heading, cohesive with the site's astro theme.

## Two things for you to decide
1. **The wording** — the section intro is a draft in your voice, edit to taste:
   > "Projects I handed to Claude with no brief beyond 'pick something you'd find interesting and build it.' It chose the topic, designed it, and wrote every line; I weighed in on direction and called when to ship. A look at what an AI makes when it's the one driving."
2. **What belongs in the corner** — I grouped the two explorables as "100% Claude-driven." If you'd count MCP Memory Server or Epistemic Mode too, just add `"claudeDriven": true` to their JSON entries and they move automatically; remove the flag to move one back.

## Verification
- `npm run build` clean, `npm test` passes (projects.json stays valid), zero console errors. Built `_site/projects/` shows the split correctly: your 5 projects, then Claude's Corner with the 2 explorables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)