### PR TITLE
Add the BZ spiral-wave mode to the reaction-diffusion explorable

### DIFF
--- a/src/reaction-diffusion/index.html
+++ b/src/reaction-diffusion/index.html
@@ -20,35 +20,60 @@
 	<main class="app">
 		<section class="stage">
 			<canvas id="cv" width="256" height="256" aria-label="Reaction-diffusion pattern"></canvas>
-			<p class="hint">Drag on the canvas to paint new seeds. Pick a regime, drag the phase map, or move the sliders.</p>
+			<p class="hint">Drag on the canvas to seed. Switch modes, pick a regime, drag the phase map.</p>
 		</section>
 
 		<aside class="panel">
-			<div class="regime" id="regime">Mitosis</div>
-			<div class="fk" id="fk-readout">feed 0.0367 · kill 0.0649</div>
-
 			<div class="group">
-				<span class="label">Phase map — drag to explore</span>
-				<canvas id="phasemap" width="272" height="168" class="phasemap" aria-label="Feed–kill phase diagram; drag to set parameters"></canvas>
-			</div>
-
-			<div class="group">
-				<span class="label">Regime</span>
-				<div class="presets">
-					<button data-preset="mitosis" aria-pressed="true">Mitosis</button>
-					<button data-preset="coral" aria-pressed="false">Coral</button>
-					<button data-preset="maze" aria-pressed="false">Maze</button>
-					<button data-preset="solitons" aria-pressed="false">Solitons</button>
-					<button data-preset="worms" aria-pressed="false">Worms</button>
-					<button data-preset="waves" aria-pressed="false">Waves</button>
+				<span class="label">Mode</span>
+				<div class="presets" role="group" aria-label="Simulation mode">
+					<button data-mode="gray" aria-pressed="true">Patterns</button>
+					<button data-mode="bz" aria-pressed="false">Waves (BZ)</button>
 				</div>
 			</div>
 
-			<div class="group">
-				<label class="slider"><span class="label">Feed <i>f</i></span>
-					<input id="f-slider" type="range" min="0.010" max="0.080" step="0.0001" value="0.0367"></label>
-				<label class="slider"><span class="label">Kill <i>k</i></span>
-					<input id="k-slider" type="range" min="0.040" max="0.070" step="0.0001" value="0.0649"></label>
+			<div class="regime" id="regime">Mitosis</div>
+
+			<!-- Gray-Scott (Patterns) controls -->
+			<div id="gray-controls">
+				<div class="fk" id="fk-readout">feed 0.0367 · kill 0.0649</div>
+
+				<div class="group">
+					<span class="label">Phase map — drag to explore</span>
+					<canvas id="phasemap" width="272" height="168" class="phasemap" aria-label="Feed–kill phase diagram; drag to set parameters"></canvas>
+				</div>
+
+				<div class="group">
+					<span class="label">Regime</span>
+					<div class="presets">
+						<button data-preset="mitosis" aria-pressed="true">Mitosis</button>
+						<button data-preset="coral" aria-pressed="false">Coral</button>
+						<button data-preset="maze" aria-pressed="false">Maze</button>
+						<button data-preset="solitons" aria-pressed="false">Solitons</button>
+						<button data-preset="worms" aria-pressed="false">Worms</button>
+						<button data-preset="waves" aria-pressed="false">Waves</button>
+					</div>
+				</div>
+
+				<div class="group">
+					<label class="slider"><span class="label">Feed <i>f</i></span>
+						<input id="f-slider" type="range" min="0.010" max="0.080" step="0.0001" value="0.0367"></label>
+					<label class="slider"><span class="label">Kill <i>k</i></span>
+						<input id="k-slider" type="range" min="0.040" max="0.070" step="0.0001" value="0.0649"></label>
+				</div>
+			</div>
+
+			<!-- BZ (Waves) controls -->
+			<div id="bz-controls" hidden>
+				<div class="group">
+					<span class="label">Seed</span>
+					<div class="presets">
+						<button data-bz="spiral" aria-pressed="true">Spiral</button>
+						<button data-bz="targets" aria-pressed="false">Targets</button>
+					</div>
+				</div>
+				<p class="bz-note">Excitable medium — waves travel and annihilate on collision; a broken
+					front curls into a rotating spiral. Drag the canvas to spark new waves.</p>
 			</div>
 
 			<div class="group buttons">
@@ -96,18 +121,18 @@
 				two-chemical system is how a featureless embryo decides where to put stripes and spots. The same
 				equations predict animal coats, seashell markings, the spacing of hair follicles. The pattern isn't
 				stored anywhere; it falls out of the chemistry.</p>
-			<p>And it has a second face. Tune the same engine into an <b>excitable</b> regime and the patterns stop sitting
-				still and start to <i>travel</i> — rotating spirals and expanding target rings. That's the
+			<p>And it has a second face. Switch the tool to <b>Waves</b> mode and the patterns stop sitting still and start
+				to <i>travel</i> — a rotating spiral, or expanding target rings. That's the
 				<a href="https://en.wikipedia.org/wiki/Belousov%E2%80%93Zhabotinsky_reaction">Belousov–Zhabotinsky
-				reaction</a>, the mesmerizing chemical clock you may have seen spiralling across a petri dish. Spots and
-				spirals look like different phenomena; they're the same two-chemicals-diffusing idea in different
-				neighbourhoods of its own phase diagram. (This tool explores the stationary-pattern side; the travelling-wave
-				side is a natural next addition.)</p>
+				reaction</a>, the mesmerizing chemical clock you may have seen spiralling across a petri dish. Under the
+				hood it's a different (excitable-medium) equation, but the idea is the same: things diffusing and reacting,
+				with a refractory "wake" behind each wave so a broken front has no choice but to curl. Spots and spirals
+				look like different phenomena; they're two neighbourhoods of the same world.</p>
 		</section>
 
 		<footer class="colophon">
-			Built as a free exploration with Claude Code. Vanilla JavaScript, a hand-written Gray-Scott solver, no
-			dependencies. The physics is real; the parameter regimes are the well-known ones from the literature.
+			Built as a free exploration with Claude Code. Vanilla JavaScript, hand-written Gray-Scott and Barkley
+			solvers, no dependencies. The physics is real; the parameters are the well-known ones from the literature.
 		</footer>
 	</article>
 

--- a/src/reaction-diffusion/src/barkley.js
+++ b/src/reaction-diffusion/src/barkley.js
@@ -1,0 +1,88 @@
+// barkley.js — the EXCITABLE-MEDIUM core: the Barkley model, which produces the rotating spiral and
+// target waves of the Belousov–Zhabotinsky reaction (the mesmerising NileRed dish). It's the OTHER
+// face of reaction-diffusion: where Gray-Scott settles into stationary patterns (spots, stripes),
+// an excitable medium carries TRAVELLING waves that annihilate on collision and curl into spirals.
+//
+// Two fields: u (the fast "excitation", like the colour front) and v (the slow "recovery", the
+// refractory wake a wave leaves behind that briefly can't re-fire):
+//   ∂u/∂t = ∇²u + (1/ε)·u·(1−u)·(u − (v+b)/a)     u flips on past a threshold set by v, then off
+//   ∂v/∂t = u − v                                  v chases u (the recovery variable), more slowly
+// Only u diffuses (the classic Barkley choice). a, b shape the excitation threshold; ε≪1 makes u the
+// fast variable. The magic is the cubic nullcline (u − (v+b)/a): it's why a wave can't immediately
+// re-enter its own refractory tail, which is exactly what forces a broken wavefront to spiral.
+
+export const A = 0.75, B = 0.06, EPS = 0.02;   // canonical spiral-forming parameters
+
+export function makeBarkley(w, h) {
+	const n = w * h;
+	return { u: new Float32Array(n), v: new Float32Array(n), u2: new Float32Array(n), v2: new Float32Array(n), w, h, display: 'u' };
+}
+
+// seedSpiral — the textbook cross-gradient seed for ONE rotating spiral: a step in u along x crossed
+// with a step in v along y. The whole LEFT HALF is excited (u=1), giving a vertical wavefront at x=w/2;
+// the whole BOTTOM HALF is refractory (v=0.5). That front is free to advance rightward where the medium
+// is rested (the top half) but is held back where it's refractory (the bottom half) — so it BREAKS at
+// mid-height, and that single free tip at (w/2, h/2) has open medium ahead and a refractory wake behind,
+// leaving it no choice but to curl in on itself and spin up a spiral. Requires the no-flux boundaries in
+// stepBarkley; on a torus the wave arms wrap and collide, shattering the rotor into a labyrinth instead.
+export function seedSpiral(st) {
+	const { u, v, w, h } = st;
+	for (let y = 0; y < h; y++)
+		for (let x = 0; x < w; x++) {
+			const i = y * w + x;
+			u[i] = x < w / 2 ? 1 : 0;
+			v[i] = y > h / 2 ? 0.5 : 0;
+		}
+}
+
+// seedTargets — a few scattered excited dots on a rested medium; each fires an expanding ring, giving
+// the concentric "target wave" look (BZ pacemaker sites).
+export function seedTargets(st, rand = Math.random) {
+	const { u, v, w, h } = st;
+	u.fill(0); v.fill(0);
+	for (let s = 0; s < 5; s++) {
+		const cx = (rand() * w) | 0, cy = (rand() * h) | 0;
+		for (let dy = -3; dy <= 3; dy++) for (let dx = -3; dx <= 3; dx++) {
+			const x = ((cx + dx) % w + w) % w, y = ((cy + dy) % h + h) % h;
+			u[y * w + x] = 1;
+		}
+	}
+}
+
+export function clearBarkley(st) { st.u.fill(0); st.v.fill(0); }
+
+// stampBarkley — excite a disk under the user's brush (set u=1), so they can trigger new waves.
+export function stampBarkley(st, cx, cy, r) {
+	const { u, w, h } = st;
+	for (let dy = -r; dy <= r; dy++) for (let dx = -r; dx <= r; dx++) {
+		if (dx * dx + dy * dy > r * r) continue;
+		u[(((cy + dy) % h + h) % h) * w + (((cx + dx) % w + w) % w)] = 1;
+	}
+}
+
+// stepBarkley — one explicit Euler step. `du` is the diffusion coefficient on u; it must be large
+// enough (relative to the recovery timescale) for the wave to outrun its own refractory wake, or the
+// excitation just dies instead of propagating. dt is kept so dt·du stays well under the explicit
+// diffusion-stability limit; u is clamped to [0,1]. Only u diffuses (the classic Barkley choice).
+export function stepBarkley(st, a, b, eps, dt, du = 1) {
+	const { u, v, u2, v2, w, h } = st;
+	const inv = 1 / eps;
+	for (let y = 0; y < h; y++) {
+		// NO-FLUX (Neumann) boundaries: clamp at the edges instead of wrapping. A torus would let the
+		// spiral's wave arms wrap around and collide with themselves, shattering one rotor into a
+		// labyrinth of wavelets; a reflecting box lets a single spiral sit and rotate cleanly.
+		const yc = y * w, ym = (y === 0 ? 0 : y - 1) * w, yp = (y === h - 1 ? h - 1 : y + 1) * w;
+		for (let x = 0; x < w; x++) {
+			const xm = x === 0 ? 0 : x - 1, xp = x === w - 1 ? w - 1 : x + 1, i = yc + x;
+			const uu = u[i], vv = v[i];
+			const lap = (u[yc + xm] + u[yc + xp] + u[ym + x] + u[yp + x]) * 0.2
+				+ (u[ym + xm] + u[ym + xp] + u[yp + xm] + u[yp + xp]) * 0.05 - uu;
+			let nu = uu + dt * (du * lap + inv * uu * (1 - uu) * (uu - (vv + b) / a));
+			if (nu < 0) nu = 0; else if (nu > 1) nu = 1;
+			u2[i] = nu;
+			v2[i] = vv + dt * (uu - vv);
+		}
+	}
+	[st.u, st.u2] = [st.u2, st.u];
+	[st.v, st.v2] = [st.v2, st.v];
+}

--- a/src/reaction-diffusion/src/main.js
+++ b/src/reaction-diffusion/src/main.js
@@ -1,93 +1,125 @@
-// main.js — the interactive reaction-diffusion explorable. Steps the Gray-Scott sim every frame,
-// renders B through a palette, and wires the controls: named-regime presets, live feed/kill sliders,
-// paint-to-seed, play/pause, reset, clear, palette. (Teaching copy + the BZ wave mode come later.)
+// main.js — the interactive reaction-diffusion explorable. Two engines, one canvas:
+//   • PATTERNS (Gray-Scott) — stationary spots/stripes/mazes (Turing morphogenesis).
+//   • WAVES (Barkley excitable medium) — travelling spiral & target waves (the BZ reaction).
+// A mode toggle swaps which engine runs and which controls show. Both are real reaction-diffusion
+// PDEs, hand-solved in vanilla JS — the two faces of the same "two things diffusing" idea.
 import { makeFields, seedSquare, step, swap, stamp, clear } from './sim.js';
+import { makeBarkley, seedSpiral, seedTargets, stepBarkley, stampBarkley, clearBarkley, A as BK_A, B as BK_B, EPS as BK_EPS } from './barkley.js';
 import { renderField, PALETTES } from './render.js';
 import { makePhaseMap } from './phasemap.js';
 
 const W = 256, H = 256;
 const $ = (id) => document.getElementById(id);
 
-// Named Gray-Scott regimes (feed f, kill k). Each lands in a different region of the phase diagram
-// and produces a distinct pattern — the values are the well-known ones from the Gray-Scott literature.
+// Gray-Scott regimes (feed f, kill k) — the well-known values from the literature.
 const PRESETS = [
 	{ id: 'mitosis', f: 0.0367, k: 0.0649, name: 'Mitosis', blurb: 'blobs that split and replicate like dividing cells' },
 	{ id: 'coral', f: 0.0545, k: 0.0620, name: 'Coral', blurb: 'branching, growing coral fronts' },
 	{ id: 'maze', f: 0.0290, k: 0.0570, name: 'Maze', blurb: 'winding labyrinth corridors' },
-	{ id: 'solitons', f: 0.0300, k: 0.0620, name: 'Solitons', blurb: 'stable persistent dots that bounce, never merging' },
+	{ id: 'solitons', f: 0.0300, k: 0.0620, name: 'Solitons', blurb: 'stable persistent dots that never merge' },
 	{ id: 'worms', f: 0.0540, k: 0.0630, name: 'Worms', blurb: 'wriggling worm-like stripes' },
-	{ id: 'waves', f: 0.0140, k: 0.0540, name: 'Waves', blurb: 'expanding wavefronts — a glimpse of the BZ regime' },
+	{ id: 'waves', f: 0.0140, k: 0.0540, name: 'Waves', blurb: 'expanding wavefronts' },
 ];
+const BZ_SEEDS = {
+	spiral: { id: 'spiral', name: 'Spiral', blurb: 'a single rotating spiral wave', seed: seedSpiral },
+	targets: { id: 'targets', name: 'Targets', blurb: 'expanding concentric rings from pacemaker sites', seed: seedTargets },
+};
 
-const state = { f: PRESETS[0].f, k: PRESETS[0].k, running: true, steps: 8, palette: PALETTES.teal };
-let phasemap = null;   // assigned after the controls are wired (see below); guarded with ?.
-const fields = makeFields(W, H);
-seedSquare(fields, 24);
+const state = { mode: 'gray', f: PRESETS[0].f, k: PRESETS[0].k, running: true, palette: PALETTES.teal, bzSeed: 'spiral' };
+let phasemap = null;
+const gray = makeFields(W, H); seedSquare(gray, 24);
+const bz = makeBarkley(W, H); seedSpiral(bz);   // initial seed only keeps bz valid; setMode('bz') reseeds on entry
 
 const cv = $('cv'), ctx = cv.getContext('2d', { alpha: false });
 const img = ctx.createImageData(W, H);
 
-// setFK — set feed/kill, sync the sliders + numeric readout. `label` describes the regime.
+// --- Gray-Scott controls -----------------------------------------------------------------
 function setFK(f, k, label) {
 	state.f = f; state.k = k;
 	$('f-slider').value = String(f); $('k-slider').value = String(k);
 	$('fk-readout').textContent = `feed ${f.toFixed(4)} · kill ${k.toFixed(4)}`;
 	if (label) $('regime').textContent = label;
 }
-
-// applyPreset — jump to a regime: set f/k, wipe the dish, drop a fresh seed so the pattern grows
-// from scratch, and mark the active button.
 function applyPreset(p) {
 	setFK(p.f, p.k, `${p.name} — ${p.blurb}`);
-	clear(fields); seedSquare(fields, 24);
+	clear(gray); seedSquare(gray, 24);
 	phasemap?.setCur(p.f, p.k);
 	document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', String(b.dataset.preset === p.id)));
 }
+const onSlider = () => {
+	setFK(+$('f-slider').value, +$('k-slider').value);
+	phasemap?.setCur(state.f, state.k);
+	$('regime').textContent = 'custom — explore the phase diagram';
+	document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', 'false'));
+};
 
-// paint-to-seed — stamp B under the pointer; map canvas client coords → grid cells (the canvas is
-// displayed larger than its 256² backing store, so scale by the rendered size).
+// --- BZ (waves) controls -----------------------------------------------------------------
+function applyBzSeed(id) {
+	state.bzSeed = id;
+	const s = BZ_SEEDS[id]; s.seed(bz);
+	$('regime').textContent = `${s.name} — ${s.blurb}`;
+	document.querySelectorAll('[data-bz]').forEach((b) => b.setAttribute('aria-pressed', String(b.dataset.bz === id)));
+}
+
+// --- mode toggle -------------------------------------------------------------------------
+function setMode(m) {
+	state.mode = m;
+	$('gray-controls').hidden = m !== 'gray';
+	$('bz-controls').hidden = m !== 'bz';
+	document.querySelectorAll('[data-mode]').forEach((b) => b.setAttribute('aria-pressed', String(b.dataset.mode === m)));
+	if (m === 'gray') applyPreset(PRESETS.find((p) => p.id === 'mitosis'));
+	else applyBzSeed(state.bzSeed);
+}
+
+// --- paint-to-seed (dispatches by mode) --------------------------------------------------
 let painting = false;
 function paintAt(ev) {
 	const r = cv.getBoundingClientRect();
 	const gx = Math.floor((ev.clientX - r.left) / r.width * W);
 	const gy = Math.floor((ev.clientY - r.top) / r.height * H);
-	stamp(fields, gx, gy, 6);
+	// Gray-Scott gets a slightly larger brush; BZ a smaller spark (a big excited blob just floods the
+	// excitable medium rather than launching a clean wave).
+	if (state.mode === 'gray') stamp(gray, gx, gy, 6); else stampBarkley(bz, gx, gy, 5);
 }
 cv.addEventListener('pointerdown', (e) => { painting = true; cv.setPointerCapture(e.pointerId); paintAt(e); });
 cv.addEventListener('pointermove', (e) => { if (painting) paintAt(e); });
 cv.addEventListener('pointerup', () => { painting = false; });
 cv.addEventListener('pointercancel', () => { painting = false; });
 
-// --- wire controls ---
-document.querySelectorAll('[data-preset]').forEach((b) =>
-	b.addEventListener('click', () => applyPreset(PRESETS.find((p) => p.id === b.dataset.preset))));
-
-const onSlider = () => { setFK(+$('f-slider').value, +$('k-slider').value); phasemap?.setCur(state.f, state.k); $('regime').textContent = 'custom — explore the phase diagram'; document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', 'false')); };
+// --- wire controls -----------------------------------------------------------------------
+document.querySelectorAll('[data-mode]').forEach((b) => b.addEventListener('click', () => setMode(b.dataset.mode)));
+document.querySelectorAll('[data-preset]').forEach((b) => b.addEventListener('click', () => applyPreset(PRESETS.find((p) => p.id === b.dataset.preset))));
+document.querySelectorAll('[data-bz]').forEach((b) => b.addEventListener('click', () => applyBzSeed(b.dataset.bz)));
 $('f-slider').addEventListener('input', onSlider);
 $('k-slider').addEventListener('input', onSlider);
-
 $('play').addEventListener('click', () => { state.running = !state.running; $('play').textContent = state.running ? '⏸ Pause' : '▶ Play'; });
-$('reset').addEventListener('click', () => { clear(fields); seedSquare(fields, 24); });
-$('clear').addEventListener('click', () => clear(fields));
+$('reset').addEventListener('click', () => {
+	if (state.mode === 'gray') { clear(gray); seedSquare(gray, 24); } else BZ_SEEDS[state.bzSeed].seed(bz);
+});
+$('clear').addEventListener('click', () => { if (state.mode === 'gray') clear(gray); else clearBarkley(bz); });
 document.querySelectorAll('[data-palette]').forEach((b) =>
 	b.addEventListener('click', () => {
 		state.palette = PALETTES[b.dataset.palette];
 		document.querySelectorAll('[data-palette]').forEach((x) => x.setAttribute('aria-pressed', String(x === b)));
 	}));
 
-// Phase map: dragging it sets f/k LIVE without reseeding, so the current pattern morphs through
-// phase space (the most illuminating way to feel how f/k shape the result).
+// --- phase map (Gray-Scott only) ---------------------------------------------------------
 phasemap = makePhaseMap($('phasemap'), PRESETS, (f, k, fresh) => {
 	setFK(f, k);
-	if (fresh) { clear(fields); seedSquare(fields, 24); }   // tap = fresh start; drag = morph live
+	if (fresh) { clear(gray); seedSquare(gray, 24); }   // tap = fresh start; drag = morph the current pattern
 	$('regime').textContent = 'custom — drag through phase space';
 	document.querySelectorAll('[data-preset]').forEach((b) => b.setAttribute('aria-pressed', 'false'));
 });
 
-// --- the loop: advance several steps per frame (RD evolves slowly), then paint the field ---
+// --- the loop: run the active engine several steps per frame, then paint -----------------
 function loop() {
-	if (state.running) for (let s = 0; s < state.steps; s++) { step(fields, state.f, state.k); swap(fields); }
-	renderField(ctx, img, fields.b, state.palette);
+	if (state.mode === 'gray') {
+		if (state.running) for (let s = 0; s < 8; s++) { step(gray, state.f, state.k); swap(gray); }
+		renderField(ctx, img, gray.b, state.palette, 0.4);
+	} else {
+		if (state.running) for (let s = 0; s < 6; s++) stepBarkley(bz, BK_A, BK_B, BK_EPS, 0.025, 12);
+		renderField(ctx, img, bz.u, state.palette, 1.0);
+	}
 	requestAnimationFrame(loop);
 }
 applyPreset(PRESETS[0]);

--- a/src/reaction-diffusion/styles.css
+++ b/src/reaction-diffusion/styles.css
@@ -36,6 +36,8 @@ body {
 	cursor: crosshair; touch-action: none; background: #000;
 }
 .hint { color: var(--ink-dim); font-size: 0.74rem; margin: 0; max-width: 512px; text-align: center; }
+.bz-note { color: var(--ink-dim); font-size: 0.72rem; line-height: 1.5; margin: 0.6rem 0 0; }
+#gray-controls, #bz-controls { display: flex; flex-direction: column; gap: 1rem; }
 
 .panel {
 	width: 320px; background: var(--panel); border: 1px solid var(--line); border-radius: 12px;


### PR DESCRIPTION
## What
The deferred **Belousov–Zhabotinsky spiral-wave mode** — now working. The reaction-diffusion explorable gains a **Waves** mode toggle alongside the Gray-Scott **Patterns** mode, running a Barkley excitable-medium PDE that produces a clean **rotating spiral** and expanding **target rings** (the NileRed petri-dish reaction you remembered).

## What I'd missed, and the fix
The earlier attempt deferred because the medium "jammed into a labyrinth." A quick diagnostic showed the waves were actually *traveling*, not frozen — so the culprit was:
1. **Toroidal boundaries** — wave arms wrap around the edges and collide with themselves, shredding one rotor into a labyrinth of wavelets. Switched to **no-flux (reflective) boundaries** so a single spiral can sit and rotate.
2. The domain-spanning seed made many sources. Switched to the **cross-gradient seed** (a u-step crossed with a v-step → exactly one free end that curls).

Both engines are genuine reaction-diffusion PDEs, hand-solved in vanilla JS at ~60fps. No fakes — consistent with the project's honesty.

## In the UI
- A **Mode** toggle: Patterns (Gray-Scott) / Waves (BZ).
- Waves mode: **Spiral** and **Targets** seeds; paint to spark new waves; play/pause/reset/clear shared.
- Explainer copy updated (the BZ "second face" is live now, not "a next addition").

## Verification + review
- In-browser: clean centered spiral, target waves, clean mode-switching, **zero JS console errors**.
- **Code-reviewed** (code-reviewer agent): no runtime bugs — the PDE core, no-flux boundaries, and mode dispatch are correct. Fixed its findings (a stale `seedSpiral` comment, a phase-map tap-reseed regression the mode rewrite introduced, the colophon).
- Built `_site/` serves it; the temp spike harness `bk-test.html` is excluded from deploy.

Merge → live on dustin.space. Housekeeping: `bk-test.html` can be deleted from the canonical source whenever — it's the throwaway spiral harness, already out of the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)