### PR TITLE
Add plain-language on-ramps to /lenia/ for non-domain readers

### DIFF
--- a/src/lenia/index.html
+++ b/src/lenia/index.html
@@ -25,6 +25,8 @@
 		<section class="stage">
 			<canvas id="cv" role="img" aria-label="Lenia world — living patterns evolving in real time"></canvas>
 			<div id="gl-error" class="gl-error" role="alert" hidden></div>
+			<p class="stage-caption">The glowing shape is a single <i>creature</i> — a self-stabilizing
+				pattern that keeps its form while it moves. The dark field around it is empty.</p>
 			<p class="hint" id="hint">Drag on the world to feed it matter. Right-drag (or hold
 				<kbd>E</kbd>) erases. Pick a specimen, then bend its parameters and watch it cope.</p>
 		</section>
@@ -44,8 +46,12 @@
 			<div class="group">
 				<span class="label">Growth — where this species lives</span>
 				<label class="slider"><span class="label">center <i>μ</i> <b id="mu-val"></b></span>
+					<span class="gloss">The neighborhood level a cell grows toward. Land near it and the
+						pattern thrives; stray far and it dies.</span>
 					<input id="mu" type="range" min="0.05" max="0.40" step="0.0005" value="0.15"></label>
 				<label class="slider"><span class="label">width <i>σ</i> <b id="sigma-val"></b></span>
+					<span class="gloss">How wide that safe band is. Narrower means a pickier, more
+						fragile creature.</span>
 					<input id="sigma" type="range" min="0.0040" max="0.0640" step="0.0002" value="0.015"></label>
 			</div>
 

--- a/src/lenia/styles.css
+++ b/src/lenia/styles.css
@@ -41,6 +41,16 @@ body {
 	border: 1px solid var(--line); border-radius: 6px;
 	cursor: crosshair; touch-action: none; background: #010304;
 }
+/* One-line "what am I looking at" caption under the world — the domain
+ * on-ramp for a technically-literate reader who's never seen Lenia: it
+ * names the creature and the empty medium so the canvas doesn't read as
+ * undifferentiated noise. Brighter than .hint (which is interaction help)
+ * because comprehension comes before interaction. */
+.stage-caption {
+	color: var(--ink); font-size: 0.78rem; line-height: 1.55;
+	margin: 0; max-width: 560px; text-align: center;
+}
+.stage-caption i { color: var(--accent); font-style: italic; }
 .hint { color: var(--ink-dim); font-size: 0.74rem; margin: 0; max-width: 560px; text-align: center; }
 .hint kbd {
 	font-family: var(--mono); font-size: 0.72rem; color: var(--ink);
@@ -85,6 +95,11 @@ body {
 .sp-blurb { font-size: 0.74rem; color: var(--ink-dim); line-height: 1.5; }
 
 .slider { display: flex; flex-direction: column; gap: 0.35rem; }
+/* Plain-language gloss under each Greek-lettered slider label. Sentence
+ * case (not the uppercase .label) marks it as prose help, not a control
+ * name — it unlocks the μ/σ vocabulary for a reader who knows software
+ * but not this domain, without dropping the actual symbols. */
+.gloss { font-size: 0.66rem; color: var(--ink-dim); line-height: 1.45; }
 input[type="range"] { width: 100%; accent-color: var(--accent); }
 .buttons { flex-direction: row; }
 


### PR DESCRIPTION
Follow-up to #106. Plain-language on-ramps so the `/lenia/` page lands for technically-literate visitors who don't have the Lenia vocabulary — additive only; the equation, the hunt narrative, and the field notes are untouched.

## What changed
- A caption under the live world naming the creature and the empty field around it, so the canvas reads as life rather than noise.
- Plain-English glosses under the μ and σ sliders describing what each parameter does to the creature.

The survey-map legend was already there (written in `main.js`).

## Testing
60/60 tests pass in the lenia-lab dev repo, including the article-counts honesty-guard that pins the page's numbers to the data. Rendered the edited page locally and confirmed the caption, both slider glosses, and the legend all display; the only console message is a favicon 404 that doesn't occur on the real site.

## Deliberately held out
- Making the creature larger by default — a real rendering change (touches the shader view and the drag-to-world mapping), not a copy edit, so kept separate.
- A Conway's-Game-of-Life parenthetical in the intro — the target audience likely knows it, so left as-is.

Say the word on either if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m3V3qL72xgCXyqaRRsNwK
