### PR TITLE
Lenia: 2x creature scale + data-backed article counts

### DIFF
--- a/explorables-manifest.json
+++ b/explorables-manifest.json
@@ -1,15 +1,15 @@
 {
 	"note": "Sync manifest for the vendored explorables. source = upstream repo (source of truth); deployed = verbatim copy under src/. Regenerate with `node tools/check-explorables-sync.js --write` after syncing an upstream into src/. Check drift with the same script and no flag.",
-	"generatedAt": "2026-07-13T17:10:08.712Z",
+	"generatedAt": "2026-07-19T10:46:32.411Z",
 	"explorables": [
 		{
 			"id": "lenia",
 			"source": "../lenia-lab",
 			"deployed": "src/lenia",
-			"sourceCommit": "6c23e08-dirty",
-			"hash": "b900c330609fd3b145c3a97a4f450ad88cc0f9a168a6ea3d1a0a55f57f81c328",
+			"sourceCommit": "af96c58",
+			"hash": "6963f789572ea52a538ceab0b1e9d715b9bcfc56c20b33f9c8b3fe0fbc5c1994",
 			"fileCount": 14,
-			"syncedAt": "2026-07-13T17:10:08.712Z"
+			"syncedAt": "2026-07-19T10:46:32.411Z"
 		},
 		{
 			"id": "reaction-diffusion",
@@ -18,7 +18,7 @@
 			"sourceCommit": null,
 			"hash": "0bc01bc0ea686ecb97254eda1aca595d06ced255182aed807d4a62a7d123fad4",
 			"fileCount": 7,
-			"syncedAt": "2026-07-13T17:10:08.712Z"
+			"syncedAt": "2026-07-19T10:46:32.411Z"
 		},
 		{
 			"id": "aperture-synthesis",
@@ -27,7 +27,7 @@
 			"sourceCommit": null,
 			"hash": "b225cc3d2ca76ba030869459e2d5a16735ec841b1c492cf67f4f098beb225273",
 			"fileCount": 22,
-			"syncedAt": "2026-07-13T17:10:08.712Z"
+			"syncedAt": "2026-07-19T10:46:32.411Z"
 		}
 	]
 }

--- a/src/lenia/data/finds.json
+++ b/src/lenia/data/finds.json
@@ -1,5 +1,10 @@
 {
 	"_source": "lenia-lab discovery sweep + curation — tools/curate.js. Every find is reproducible: reseed tools/search.js's world with the recorded seed at (mu, sigma) and it re-emerges.",
+	"stats": {
+		"mutantMovers": 510,
+		"keptAfterDedupe": 16,
+		"shippedAfterVerification": 11
+	},
 	"finds": [
 		{
 			"code": "LL1",

--- a/src/lenia/src/main.js
+++ b/src/lenia/src/main.js
@@ -11,7 +11,16 @@ import { CpuSim } from './core/sim.js';
 import { decodeCells } from './core/rle.js';
 import { mulberry32 } from './core/rng.js';
 
-const WORLD_N = 256;
+// World size for the LIVE view. 128 — not the 256 the curator verifies at —
+// is a presentation choice: the canvas is a fixed ~560 CSS px, so cells (and
+// creatures) render twice as large, and the page's first impression is a
+// clearly visible organism instead of a distant speck. Same N the discovery
+// search ran at, so everything on the bench provably lives at this size.
+// Must stay a power of 2: the parity probe drives src/core/sim.js (radix-2
+// FFT) at the page's world size. Alternative considered: keep 256 and add a
+// creature-tracking camera to the display shader — rejected as a whole
+// zoom/pan/brush-remap subsystem where one constant suffices.
+const WORLD_N = 128;
 
 // (μ, σ) ranges shared by the sliders, the survey map axes, and the search
 // sweep (tools/search.js uses the same values — keep in sync, they define
@@ -320,8 +329,9 @@ function wireKeyboardBrush(canvas, splatAt) {
 	};
 	const show = () => { dot.hidden = false; place(); };
 
-	// 8 cells per press: coarse enough to cross the 256-cell world quickly,
-	// fine enough to place matter on a specific creature.
+	// WORLD_N/32 cells per press — 32 presses to cross the world regardless of
+	// its size: coarse enough to traverse quickly, fine enough to place matter
+	// on a specific creature (a creature body spans several STEPs).
 	const STEP = WORLD_N / 32;
 	canvas.addEventListener('keydown', (e) => {
 		let handled = true;


### PR DESCRIPTION
The two remaining quality items from the Lenia Lab self-assessment, synced from upstream lenia-lab `af96c58` (explorables-manifest re-stamped; `check-explorables-sync.js` reports clean).

## What changed
- **Creatures render 2× larger.** `WORLD_N` 256 → 128: same fixed canvas, so every cell doubles in size and the page opens on a clearly visible organism instead of a distant speck. Display-only — the curator still verifies finds at 256², and 128 is the world size the discovery search itself ran at. The alternative (a tracking camera at 256) was rejected as a zoom/pan/brush-remap subsystem where one constant suffices.
- **The article's last two numbers are now data-backed.** curate.js records the curation-run counts (510 mutant movers / 16 distinct / 11 shipped) into finds.json `stats` at generation time, and the upstream honesty test checks the prose against them instead of pinned constants (closes DEF-QA-03).

## Testing
Upstream suite 60/60 including the rewritten article-counts test. Curator re-run produced finds.json byte-identical except the 5-line stats block, with counts matching the prose exactly. Browser-verified at the new world size: creature legible with visible internal structure, pointer brush works, keyboard feed cursor position math confirmed exact (one ArrowLeft → 262.03px, matching 60/128 × 559px). Eleventy build clean.

## Note on #107
Superseded and closed: its caption + slider glosses reached `main` via #120's upstream tree sync on July 13, so they're already live in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3Ve4HhiMDEFYJpeszEL9s
